### PR TITLE
Auto hide the menu bar

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -50,7 +50,8 @@ function createWindow () {
     'height': winState.height,
     'minWidth': 600,
     'minHeight': 400,
-    show: false
+    show: false,
+    autoHideMenuBar: true
   })
 
   // Register listeners on the window, so we can update the state

--- a/app/index.js
+++ b/app/index.js
@@ -204,14 +204,12 @@ function loadMenu() {
         {
           visible: process.platform === 'darwin' ? false : true,
           label: 'Hide Menu Bar',
-          sublabel: 'Show again with Alt key',
-          type: 'checkbox',
+          accelerator: 'Alt + m',
           click() {
-            if (win.isMenuBarAutoHide()) {
-              win.setAutoHideMenuBar(false)
-            } else {
-              win.setAutoHideMenuBar(true)
+            if (win.isMenuBarVisible(true)) {
               win.setMenuBarVisibility(false)
+            } else {
+              win.setMenuBarVisibility(true)
             }
           }
         }

--- a/app/index.js
+++ b/app/index.js
@@ -203,6 +203,7 @@ function loadMenu() {
           role: 'togglefullscreen'
         },
         {
+          visible: process.platform === 'darwin' ? false : true,
           label: 'Toggle Menu Bar',
           type: 'checkbox',
           click() {

--- a/app/index.js
+++ b/app/index.js
@@ -201,6 +201,18 @@ function loadMenu() {
         },
         {
           role: 'togglefullscreen'
+        },
+        {
+          label: 'Toggle Menu Bar',
+          type: 'checkbox',
+          click() {
+            if (win.isMenuBarAutoHide()) {
+              win.setAutoHideMenuBar(false)
+            } else {
+              win.setAutoHideMenuBar(true)
+              win.setMenuBarVisibility(false)
+            }
+          }
         }
       ]
     },

--- a/app/index.js
+++ b/app/index.js
@@ -51,7 +51,6 @@ function createWindow () {
     'minWidth': 600,
     'minHeight': 400,
     show: false,
-    autoHideMenuBar: true
   })
 
   // Register listeners on the window, so we can update the state
@@ -204,7 +203,8 @@ function loadMenu() {
         },
         {
           visible: process.platform === 'darwin' ? false : true,
-          label: 'Toggle Menu Bar',
+          label: 'Hide Menu Bar',
+          sublabel: 'Show again with Alt key',
           type: 'checkbox',
           click() {
             if (win.isMenuBarAutoHide()) {


### PR DESCRIPTION
Resolves #96, menu bar is auto hidden when the app is started, can be shown using the alt key, and can be toggled to show at all times via the view menu.