### PR TITLE
standardnotes/desktop is now available in the AUR!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,23 @@
 This application makes use of the core JS/CSS/HTML code found in the [web repo](https://github.com/standardnotes/web). For issues related to the actual app experience, please post issues in the web repo.
 
+## Building
+
 Build for all platforms:
 ```
-electron-packager . "Standard Notes" --platform=all --icon=icon/icon --overwrite --osx-sign='Mac Developer ID Application: xxx' --out=dist
+electron-packager . "Standard Notes" \
+  --platform=all \
+  --icon=icon/icon \
+  --overwrite \
+  --osx-sign='Mac Developer ID Application: xxx' \
+  --out=dist
 ```
 
-### Linux users: to run an AppImage file, simply:
+## Installation
 
-chmod a+x standard-notes---.AppImage
+On Linux, download the latest AppImage from the [Releases](https://github.com/standardnotes/desktop/releases/latest) page, and give it executable permission.
+
+Standard Notes is also available on the AUR as [sn-bin](https://aur.archlinux.org/packages/sn-bin/)!
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ On Linux, download the latest AppImage from the [Releases](https://github.com/st
 
 `chmod u+x standard-notes*.AppImage`
 
-Standard Notes is also unofficially available on the AUR as [sn-bin](https://aur.archlinux.org/packages/sn-bin/), which is currently maintained by [JoshuaRLi](https://github.com/JoshuaRLi).
+## Alternative Downloads
 
+The Standard Notes desktop client is also available through a variety of package managers:
+
+* [unofficial] **AUR:** [sn-bin](https://aur.archlinux.org/packages/sn-bin/), currently maintained by [JoshuaRLi](https://github.com/JoshuaRLi)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ electron-packager . "Standard Notes" \
 
 ## Installation
 
-On Linux, download the latest AppImage from the [Releases](https://github.com/standardnotes/desktop/releases/latest) page, and give it executable permission.
+On Linux, download the latest AppImage from the [Releases](https://github.com/standardnotes/desktop/releases/latest) page, and give it executable permission:
+
+`chmod u+x standard-notes*.AppImage`
 
 Standard Notes is also available on the AUR as [sn-bin](https://aur.archlinux.org/packages/sn-bin/)!
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ On Linux, download the latest AppImage from the [Releases](https://github.com/st
 
 `chmod u+x standard-notes*.AppImage`
 
-Standard Notes is also available on the AUR as [sn-bin](https://aur.archlinux.org/packages/sn-bin/)!
+Standard Notes is also unofficially available on the AUR as [sn-bin](https://aur.archlinux.org/packages/sn-bin/), which is currently maintained by [JoshuaRLi](https://github.com/JoshuaRLi).
 
 
 ## License


### PR DESCRIPTION
Hey Mo!

Starting from 2.0.42 I'll be maintaining an AUR package for the AppImage. I've added a link in the README and also cleaned it up a bit.