### PR TITLE
added non-binary AUR package ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,6 @@ On Linux, download the latest AppImage from the [Releases](https://github.com/st
 
 The Standard Notes desktop client is also available through a variety of package managers:
 
-* [unofficial] **AUR:** [sn-bin](https://aur.archlinux.org/packages/sn-bin/), currently maintained by [JoshuaRLi](https://github.com/JoshuaRLi)
+* [unofficial] **AUR:** [sn-bin](https://aur.archlinux.org/packages/sn-bin/), binary package, currently maintained by [JoshuaRLi](https://github.com/JoshuaRLi)
+* [unofficial] **AUR:** [standardnotes-desktop](https://aur.archlinux.org/packages/standardnotes-desktop/), non binary package - built from source, currently maintained by [danielhass](https://github.com/danielhass)
+


### PR DESCRIPTION
Also added the non binary package reference to the AUR.
Now the users have the ability to choose between the AppImage binary package and the one that builds form source.