### PR TITLE
Add support for building snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "electron": "1.8.4",
-    "electron-builder": "20.13.3"
+    "electron-builder": "20.14.7"
   },
   "build": {
     "appId": "org.standardnotes.standardnotes",
@@ -34,7 +34,8 @@
         "StartupWMClass": "standard notes"
       },
       "target": [
-        "AppImage"
+        "AppImage",
+        "snap"
       ]
     }
   },


### PR DESCRIPTION
This should fix #129 . 

As discussed on the [forum thread](https://github.com/standardnotes/forum/issues/77#issuecomment-430671527) this PR adds the capability to build a snap package for standardnotes. I have built this locally in an Ubuntu 16.04 lxc container and have tested the resulting snap on my KDE Neon laptop. It functions exactly the same, unmodified as the existing package as far as I can tell. 

The bump to electron-builder is required to ensure that essential security requirements are fulfilled when building the snap. The snap store will likely reject a snap built with earlier versions of electron-builder.

If accepted I'd recommend signing up and [registering](https://docs.snapcraft.io/registering-your-app-name/6793) the standardnotes name in the snap store, and doing a test [upload](https://docs.snapcraft.io/releasing-your-app/6795) of the latest stable release. I am happy to help test across a number of popular distros. As previously mentioned, we have documentation on how to get the store page to 'pop' and we can help promote the application once that's done. Applications promoted as editor's picks in GNOME Software on Ubuntu often see a significant uptick in user downloads.

Happy to answer any questions here.