### PR TITLE
Reuse existing window if present

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -152,16 +152,29 @@ app.on('activate', function() {
   updateManager.checkForUpdate();
 });
 
-app.on('ready', function(){
-  if(!win) {
-    createWindow();
-  } else {
-    win.focus();
+const isSecondInstance = app.makeSingleInstance((commandLine, workingDirectory) => {
+  // Someone tried to run a second instance, we should focus our window.
+  if (win) {
+    if (win.isMinimized()) win.restore()
+    win.focus()
   }
+})
 
-  menuManager.loadMenu(win, archiveManager, updateManager);
-  updateManager.onNeedMenuReload = () => {
-    menuManager.reload();
+app.on('ready', function(){
+
+  if (isSecondInstance) {
+    app.quit()
+  } else {
+    if(!win) {
+      createWindow();
+    } else {
+      win.focus();
+    }
+
+    menuManager.loadMenu(win, archiveManager, updateManager);
+    updateManager.onNeedMenuReload = () => {
+      menuManager.reload();
+    }
   }
 })
 


### PR DESCRIPTION
On Linux, at least, if an instance of the application is open the application is opened again (clicking the icon, using a launcher etc) the following error is displayed.

(MacOS automatically re-uses the existing instance and shows the user the currently open app)

![Screenshot from 2019-05-13 20-33-11](https://user-images.githubusercontent.com/154176/57607904-2d8e9380-75c0-11e9-9f41-a6652c60d081.png)

The user needs to close the dialogue, close the window and find their existing instance to use. This is especially visible when using multiple workspaces/monitors with lots of windows and "switching" by using a launcher (searching for standard notes). 

The desired action I believe is show the existing, usable, instance of the application instead of the error.

There is an API in Electron for this purpose: https://github.com/electron/electron/blob/1-8-x/docs/api/app.md#appmakesingleinstancecallback

This PR implements that API call as per the docs. 

1. If Standard Notes is not open create a new window and focus it (existing behaviour)
2. If Standard Notes is already open focus that window (restore if minimised) and quit the second instance which was just opened.


(The contents of the ready event callback are wrapped to avoid them running in the case that we're inside the second instance, to prevent an error on exit)