### PR TITLE
feat: persist application zoom across restarts

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -13,6 +13,7 @@ import archiveManager from './javascripts/main/archiveManager.js';
 import packageManager from './javascripts/main/packageManager.js';
 import searchManager from './javascripts/main/searchManager.js';
 import updateManager from './javascripts/main/updateManager.js';
+import zoomManager from './javascripts/main/zoomManager.js';
 
 ipcMain.on('initial-data-loaded', () => {
   archiveManager.beginBackups();
@@ -75,6 +76,7 @@ function createWindow () {
   archiveManager.setWindow(win);
   packageManager.setWindow(win);
   updateManager.setWindow(win);
+  zoomManager.setWindow(win);
 
   // Register listeners on the window, so we can update the state
   // automatically (the listeners will be removed when the window

--- a/app/javascripts/main/zoomManager.js
+++ b/app/javascripts/main/zoomManager.js
@@ -1,0 +1,29 @@
+const store = require('./store')
+
+class ZoomManager {
+
+  setWindow(window) {
+    this.window = window;
+    this.bind();
+  }
+
+  bind() {
+    // We can't rely on ready-to-show as it doesn't fire consistently
+    // See: https://github.com/electron/electron/issues/7779
+    this.window.webContents.on('dom-ready', () => {
+      const zoomFactor = store.instance().get('zoomFactor');
+      if (zoomFactor) {
+        this.window.webContents.setZoomFactor(zoomFactor);
+      }
+    })
+
+    this.window.on('close', () => {
+      // Persist the zoom level
+      this.window.webContents.getZoomFactor((zoomFactor) => {
+        store.instance().set('zoomFactor', zoomFactor);
+      });
+    })
+  }
+}
+
+export default new ZoomManager();


### PR DESCRIPTION
The zoom setting is not persisted consistently across environments due to the way Electron/Chromium persists the state for each window.

Each file opened is persisted by Electron as a key value pair: `{"file:///<app_location>/<file>.html":1.0}`.

This ties the location of the files to the zoom factor setting.

Since we're using **AppImage** to distribute the application in Linux, when the user runs the application it will be mounted on a temporary folder that changes every time. This makes Electron unable to find the previous zoom setting.

To fix this we're saving the zoom setting ourselves and restoring it when the application starts.

Closes: #50 