### PR TITLE
Add Feature Flag for SingleInstance Check

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -152,13 +152,29 @@ app.on('activate', function() {
   updateManager.checkForUpdate();
 });
 
-const isSecondInstance = app.makeSingleInstance((commandLine, workingDirectory) => {
-  // Someone tried to run a second instance, we should focus our window.
+// feature flag: https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md#appmakesingleinstance
+const hasRequestSingleInstanceLock = app.requestSingleInstanceLock ? true : false;
+let isSecondInstance = null;
+
+// Someone tried to run a second instance, we should focus our window.
+const handleSecondInstance = (argv, cwd) => {
   if (win) {
     if (win.isMinimized()) win.restore()
     win.focus()
   }
-})
+}
+
+if (hasRequestSingleInstanceLock) {
+  isSecondInstance = !app.requestSingleInstanceLock()
+
+  app.on('second-instance', (event, argv, cwd) => {
+    handleSecondInstance(argv, cwd)
+  })
+} else {
+  isSecondInstance = app.makeSingleInstance((argv, cwd) => {
+    handleSecondInstance(argv, cwd)
+  })
+}
 
 app.on('ready', function(){
 


### PR DESCRIPTION
ref #358 

Some people are building StandardNotes with a higher version of Electron that it targets.

The single instance check (introduced in #339) used was deprecated between v3 and v4 Electron API: https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md#planned-breaking-api-changes-40

This PR adds a feature flag to check which version of the API is used and handle accordingly.
Tested on Electron v1.8.8 and v4.1.4

By the way, here's what this would look like after Electron v4 API.

```diff
diff --git a/app/index.js b/app/index.js
index 8dd68da..23dcfe4 100644
--- a/app/index.js
+++ b/app/index.js
@@ -152,10 +152,6 @@ app.on('activate', function() {
   updateManager.checkForUpdate();
 });
 
-// feature flag: https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md#appmakesingleinstance
-const hasRequestSingleInstanceLock = app.requestSingleInstanceLock ? true : false;
-let isSecondInstance = null;
-
 // Someone tried to run a second instance, we should focus our window.
 const handleSecondInstance = (argv, cwd) => {
   if (win) {
@@ -164,17 +160,12 @@ const handleSecondInstance = (argv, cwd) => {
   }
 }
 
-if (hasRequestSingleInstanceLock) {
-  isSecondInstance = !app.requestSingleInstanceLock()
+const isSecondInstance = !app.requestSingleInstanceLock()
+
+app.on('second-instance', (event, argv, cwd) => {
+  handleSecondInstance(argv, cwd)
+})
 
-  app.on('second-instance', (event, argv, cwd) => {
-    handleSecondInstance(argv, cwd)
-  })
-} else {
-  isSecondInstance = app.makeSingleInstance((argv, cwd) => {
-    handleSecondInstance(argv, cwd)
-  })
-}
 
 app.on('ready', function(){
 ```