### PR TITLE
chore: allow open external files

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -124,19 +124,15 @@ function createWindow () {
 
   // handle link clicks
   win.webContents.on('new-window', function(e, url) {
-    if(!url.includes("file://")) {
-      e.preventDefault();
-      shell.openExternal(url);
-    }
+    e.preventDefault();
+    shell.openExternal(url);
   });
 
   // handle link clicks (this event is fired instead of
   // 'new-window' when target is not set to _blank)
   win.webContents.on('will-navigate', function(e, url) {
-    if(!url.includes("file://")) {
-      e.preventDefault();
-      shell.openExternal(url);
-    }
+    e.preventDefault();
+    shell.openExternal(url);
   });
 }
 


### PR DESCRIPTION
As discussed this seems to have been prevented intentionally due to security concerns.

I would suggest allowing external files to be opened since all notes content is controlled by the user hence the potential vectors of attack are limited.

We can also improve upon this solution by providing additional security measures:
- Require manual confirmation from the user when the application tries to open a `file://` link. This could be done by displaying a confirmation Dialog.
- Allow the users to configure a white list of folders, the app would only allow opening files in one of those folders. This solution could be harder to implement since we would have to explore if it makes sense for mobile apps.

## Windows Demo

![open_external_win](https://user-images.githubusercontent.com/10207818/61080202-6ca06000-a41c-11e9-86cc-82c8acbccbdf.gif)

Closes standardnotes/bounties#35