### PR TITLE
Fix sums script, #471

### DIFF
--- a/sums.rb
+++ b/sums.rb
@@ -1,19 +1,21 @@
+#!/usr/bin/env ruby
+
 require 'json'
 
 package = JSON.parse(File.read("package.json"))
 version = package["version"]
 
 files = [
-  "Standard Notes-#{version}-mac.zip",
+  "Standard-Notes-#{version}-mac.zip",
 
-  "Standard Notes-#{version}.dmg",
-  "Standard Notes-#{version}.dmg.blockmap",
+  "Standard-Notes-#{version}.dmg",
+  "Standard-Notes-#{version}.dmg.blockmap",
 
-  "Standard Notes-#{version}-i386.AppImage",
-  "Standard Notes-#{version}.AppImage",
+  "Standard-Notes-#{version}-i386.AppImage",
+  "Standard-Notes-#{version}.AppImage",
 
-  "Standard Notes Setup #{version}.exe",
-  "Standard Notes Setup #{version}.exe.blockmap",
+  "Standard-Notes-Setup-#{version}.exe",
+  "Standard-Notes-Setup-#{version}.exe.blockmap",
 
   "standard-notes_#{version}_amd64.snap",
 


### PR DESCRIPTION
As mentioned in the #471, 

> Currently the SHA256SUMS file provided with the releases do not contain the correct file names. Running a sha256sum -c SHA256SUMS fails to verify the files since in my case the Appimage I want to use Standard-Notes-3.0.25.AppImage shows as Standard Notes-3.0.25.AppImage in the SHA256SUMS file.

This tiny PR:
* fixes the filenames in the `sums.rb` file
* adds ruby shebang for proper execution without calling the script using a ruby interpreter