### PR TITLE
Add i18n mechanisms

### DIFF
--- a/app/application.js
+++ b/app/application.js
@@ -11,7 +11,7 @@ import {
 } from './javascripts/main';
 import { isWindows, isMac, isLinux } from './javascripts/main/platforms';
 import { Store, StoreKeys } from './javascripts/main/store';
-import { AppName } from './javascripts/main/strings';
+import { AppName, initializeStrings } from './javascripts/main/strings';
 import { IpcMessages } from './javascripts/shared/ipcMessages';
 import index from './index.html';
 import { CommandLineArgs } from './javascripts/shared/CommandLineArgs';
@@ -99,6 +99,7 @@ class DesktopApplication {
         console.warn('Quiting app and focusing existing instance.');
         app.quit();
       } else {
+        initializeStrings(app.getLocale());
         this.createExtensionsServer();
         this.createWindow();
 

--- a/app/javascripts/main/extServer.ts
+++ b/app/javascripts/main/extServer.ts
@@ -5,7 +5,7 @@ import mime from 'mime-types';
 import path from 'path';
 import { URL } from 'url';
 import { FileDoesNotExist } from './fileUtils';
-import { extensions as s } from './strings';
+import { extensions as str } from './strings';
 
 const Protocol = 'http';
 const UserDataPath = app.getPath('userData');
@@ -66,7 +66,7 @@ function onRequestError(error: Error | { code: string }, res: ServerResponse) {
     responseCode = 500;
   }
   res.writeHead(responseCode);
-  res.write(s().unableToLoadExtension);
+  res.write(str().unableToLoadExtension);
   res.end();
 }
 

--- a/app/javascripts/main/extServer.ts
+++ b/app/javascripts/main/extServer.ts
@@ -5,7 +5,7 @@ import mime from 'mime-types';
 import path from 'path';
 import { URL } from 'url';
 import { FileDoesNotExist } from './fileUtils';
-import { UnableToLoadExtension } from './strings';
+import { extensions as s } from './strings';
 
 const Protocol = 'http';
 const UserDataPath = app.getPath('userData');
@@ -66,7 +66,7 @@ function onRequestError(error: Error | { code: string }, res: ServerResponse) {
     responseCode = 500;
   }
   res.writeHead(responseCode);
-  res.write(UnableToLoadExtension);
+  res.write(s().unableToLoadExtension);
   res.end();
 }
 

--- a/app/javascripts/main/menuManager.ts
+++ b/app/javascripts/main/menuManager.ts
@@ -5,6 +5,7 @@ import { TrayManager } from './trayManager';
 import { SpellcheckerManager } from './spellcheckerManager';
 import { MenuItemConstructorOptions, app, Menu, dialog, shell } from 'electron';
 import { isMac } from './platforms';
+import { appMenu as s } from './strings';
 
 export function createMenuManager({
   window,
@@ -87,70 +88,6 @@ const KeyCombinations = {
   AltM: 'Alt + m'
 };
 
-const Labels = {
-  Edit: 'Edit',
-  View: 'View',
-  HideMenuBar: 'Hide Menu Bar',
-  UseThemedMenuBar: 'Use Themed Menu Bar',
-  MinimizeToTrayOnClose: 'Minimize To Tray On Close',
-  Backups: 'Backups',
-  AutomaticUpdatesEnabled: 'Automatic Updates Enabled',
-  AutomaticUpdatesDisabled: 'Automatic Updates Disabled',
-  DisableAutomaticBackups: 'Disable Automatic Backups',
-  EnableAutomaticBackups: 'Enable Automatic Backups',
-  ChangeBackupsLocation: 'Change Backups Location',
-  OpenBackupsLocation: 'Open Backups Location',
-  EmailSupport: 'Email Support',
-  Website: 'Website',
-  GitHub: 'GitHub',
-  Slack: 'Slack',
-  Twitter: 'Twitter',
-  ToggleErrorConsole: 'Toggle Error Console',
-  OpenDataDirectory: 'Open Data Directory',
-  ClearCacheAndReload: 'Clear Cache and Reload',
-  Speech: 'Speech',
-  Close: 'Close',
-  Minimize: 'Minimize',
-  Zoom: 'Zoom',
-  BringAllToFront: 'Bring All to Front',
-  CheckForUpdate: 'Check for Update',
-  CheckingForUpdate: 'Checking for update…',
-  UpdateAvailable: '(1) Update Available',
-  Updates: 'Updates',
-  ErrorRetrieving: 'Error Retrieving',
-  OpenDownloadLocation: 'Open Download Location',
-  DownloadingUpdate: 'Downloading Update…',
-  ManuallyDownloadUpdate: 'Manually Download Update',
-  SpellcheckerLanguages: 'Spellchecker Languages',
-  installPendingUpdate(versionNumber: string) {
-    return `Install Pending Update (${versionNumber})`;
-  },
-  lastUpdateCheck(date: Date) {
-    return `Last checked ${date.toLocaleString()}`;
-  },
-  version(number: string) {
-    return `Version: ${number}`;
-  },
-  yourVersion(number: string) {
-    return `Your Version: ${number}`;
-  },
-  latestVersion(number: string) {
-    return `Latest Version: ${number}`;
-  },
-  viewReleaseNotes(versionNumber: string) {
-    return `View ${versionNumber} Release Notes`;
-  }
-};
-
-const MessageBoxTitles = {
-  PreferenceChanged: 'Preference Changed'
-};
-const MessageBoxMessages = {
-  MenuBarPreferenceSaved:
-    'Your menu bar preference has been saved. ' +
-    'Please restart the application for the change to take effect.'
-};
-
 const enum MenuItemTypes {
   CheckBox = 'checkbox',
   Radio = 'radio'
@@ -204,7 +141,7 @@ function editMenu(
   reload: () => any
 ): MenuItemConstructorOptions {
   return {
-    label: Labels.Edit,
+    label: s().edit,
     submenu: [
       {
         role: Roles.Undo
@@ -237,7 +174,7 @@ function editMenu(
 
 function macSpeechMenu(): MenuItemConstructorOptions {
   return {
-    label: Labels.Speech,
+    label: s().speech,
     submenu: [
       {
         role: Roles.StopSeeking
@@ -254,7 +191,7 @@ function spellcheckerMenu(
   reload: () => any
 ): MenuItemConstructorOptions {
   return {
-    label: Labels.SpellcheckerLanguages,
+    label: s().spellcheckerLanguages,
     submenu: spellcheckerManager.languages().map(
       ({ name, code, enabled }): MenuItemConstructorOptions => {
         return {
@@ -281,13 +218,13 @@ function viewMenu(
   reload: () => any
 ): MenuItemConstructorOptions {
   return {
-    label: Labels.View,
+    label: s().view,
     submenu: [
       {
         role: Roles.Reload
       },
       {
-        role: 'toggleDevTools'
+        role: Roles.ToggleDevTools
       },
       Separator,
       {
@@ -319,7 +256,7 @@ function menuBarOptions(
   return [
     {
       visible: !isMac && useSystemMenuBar,
-      label: Labels.HideMenuBar,
+      label: s().hideMenuBar,
       accelerator: KeyCombinations.AltM,
       click: () => {
         isMenuBarVisible = !isMenuBarVisible;
@@ -328,15 +265,15 @@ function menuBarOptions(
       }
     },
     {
-      label: Labels.UseThemedMenuBar,
+      label: s().useThemedMenuBar,
       type: MenuItemTypes.CheckBox,
       checked: !useSystemMenuBar,
       click: () => {
         store.set(StoreKeys.UseSystemMenuBar, !useSystemMenuBar);
         reload();
         dialog.showMessageBox({
-          title: MessageBoxTitles.PreferenceChanged,
-          message: MessageBoxMessages.MenuBarPreferenceSaved
+          title: s().preferencesChanged.title,
+          message: s().preferencesChanged.message
         });
       }
     }
@@ -364,22 +301,22 @@ function windowMenu(store: Store, trayManager: TrayManager, reload: () => any): 
 function macWindowItems(): MenuItemConstructorOptions[] {
   return [
     {
-      label: Labels.Close,
+      label: s().close,
       accelerator: KeyCombinations.CmdOrCtrlW,
       role: Roles.Close
     },
     {
-      label: Labels.Minimize,
+      label: s().minimize,
       accelerator: KeyCombinations.CmdOrCtrlM,
       role: Roles.Minimize
     },
     {
-      label: Labels.Zoom,
+      label: s().zoom,
       role: Roles.Zoom
     },
     Separator,
     {
-      label: Labels.BringAllToFront,
+      label: s().bringAllToFront,
       role: Roles.Front
     }
   ];
@@ -392,7 +329,7 @@ function minimizeToTrayItem(
 ) {
   const minimizeToTray = trayManager.shouldMinimizeToTray();
   return {
-    label: Labels.MinimizeToTrayOnClose,
+    label: s().minimizeToTrayOnClose,
     type: MenuItemTypes.CheckBox,
     checked: minimizeToTray,
     click() {
@@ -409,12 +346,12 @@ function minimizeToTrayItem(
 
 function backupsMenu(archiveManager: ArchiveManager, reload: () => any) {
   return {
-    label: Labels.Backups,
+    label: s().backups,
     submenu: [
       {
         label: archiveManager.isBackupsEnabled()
-          ? Labels.DisableAutomaticBackups
-          : Labels.EnableAutomaticBackups,
+          ? s().disableAutomaticBackups
+          : s().enableAutomaticBackups,
         click() {
           archiveManager.toggleBackupsStatus();
           reload();
@@ -422,13 +359,13 @@ function backupsMenu(archiveManager: ArchiveManager, reload: () => any) {
       },
       Separator,
       {
-        label: Labels.ChangeBackupsLocation,
+        label: s().changeBackupsLocation,
         click() {
           archiveManager.changeBackupsLocation();
         }
       },
       {
-        label: Labels.OpenBackupsLocation,
+        label: s().openBackupsLocation,
         click() {
           shell.openItem(archiveManager.getBackupsLocation());
         }
@@ -442,18 +379,18 @@ function updateMenu(updateManager: UpdateManager) {
   const updateNeeded = updateManager.updateNeeded();
   let label;
   if (updateData.checkingForUpdate) {
-    label = Labels.CheckingForUpdate;
+    label = s().checkingForUpdate;
   } else if (updateNeeded) {
-    label = Labels.UpdateAvailable;
+    label = s().updateAvailable;
   } else {
-    label = Labels.Updates;
+    label = s().updates;
   }
   const submenu: MenuItemConstructorOptions[] = [];
   const structure = { label, submenu };
 
   if (updateManager.autoupdateDownloaded()) {
     submenu.push({
-      label: Labels.installPendingUpdate(
+      label: s().installPendingUpdate(
         updateManager.autoupdateDownloadedVersion()
       ),
       click() {
@@ -464,8 +401,8 @@ function updateMenu(updateManager: UpdateManager) {
 
   submenu.push({
     label: updateManager.autoupdateEnabled()
-      ? Labels.AutomaticUpdatesEnabled
-      : Labels.AutomaticUpdatesDisabled,
+      ? s().automaticUpdatesEnabled
+      : s().automaticUpdatesDisabled,
     click() {
       updateManager.toggleAutoupdateStatus();
     }
@@ -475,14 +412,14 @@ function updateMenu(updateManager: UpdateManager) {
 
   if (updateData.lastCheck && !updateData.checkinForUpdate) {
     submenu.push({
-      label: Labels.lastUpdateCheck(updateData.lastCheck),
+      label: s().lastUpdateCheck(updateData.lastCheck),
       click: () => {}
     });
   }
 
   if (!updateData.checkinForUpdate) {
     submenu.push({
-      label: Labels.CheckForUpdate,
+      label: s().checkForUpdate,
       click: () => {
         updateManager.checkForUpdate({ userTriggered: true });
       }
@@ -492,15 +429,15 @@ function updateMenu(updateManager: UpdateManager) {
   submenu.push(Separator);
 
   submenu.push({
-    label: Labels.yourVersion(updateData.currentVersion),
+    label: s().yourVersion(updateData.currentVersion),
     click: () => {}
   });
 
   const latestVersion = updateManager.latestVersion();
   submenu.push({
     label: latestVersion
-      ? Labels.latestVersion(latestVersion)
-      : Labels.ErrorRetrieving,
+      ? s().latestVersion(latestVersion)
+      : s().errorRetrieving,
     click() {
       updateManager.openChangelog();
     }
@@ -509,7 +446,7 @@ function updateMenu(updateManager: UpdateManager) {
   submenu.push(Separator);
 
   submenu.push({
-    label: Labels.viewReleaseNotes(latestVersion),
+    label: s().viewReleaseNotes(latestVersion),
     click() {
       updateManager.openChangelog();
     }
@@ -517,7 +454,7 @@ function updateMenu(updateManager: UpdateManager) {
 
   if (updateData.latestDownloaded) {
     submenu.push({
-      label: Labels.OpenDownloadLocation,
+      label: s().openDownloadLocation,
       click() {
         updateManager.openDownloadLocation();
       }
@@ -525,8 +462,8 @@ function updateMenu(updateManager: UpdateManager) {
   } else if (updateNeeded || updateData.downloadingUpdate) {
     submenu.push({
       label: updateData.downloadingUpdate
-        ? Labels.DownloadingUpdate
-        : Labels.ManuallyDownloadUpdate,
+        ? s().downloadingUpdate
+        : s().manuallyDownloadUpdate,
       click() {
         updateData.downloadingUpdate
           ? updateManager.openDownloadLocation()
@@ -543,51 +480,51 @@ function helpMenu(window: Electron.BrowserWindow, shell: Electron.Shell) {
     role: Roles.Help,
     submenu: [
       {
-        label: Labels.EmailSupport,
+        label: s().emailSupport,
         click() {
           shell.openExternal(Urls.Support);
         }
       },
       {
-        label: Labels.Website,
+        label: s().website,
         click() {
           shell.openExternal(Urls.Website);
         }
       },
       {
-        label: Labels.GitHub,
+        label: s().gitHub,
         click() {
           shell.openExternal(Urls.GitHub);
         }
       },
       {
-        label: Labels.Slack,
+        label: s().slack,
         click() {
           shell.openExternal(Urls.Slack);
         }
       },
       {
-        label: Labels.Twitter,
+        label: s().twitter,
         click() {
           shell.openExternal(Urls.Twitter);
         }
       },
       Separator,
       {
-        label: Labels.ToggleErrorConsole,
+        label: s().toggleErrorConsole,
         click() {
           window.webContents.toggleDevTools();
         }
       },
       {
-        label: Labels.OpenDataDirectory,
+        label: s().openDataDirectory,
         click() {
           const userDataPath = app.getPath('userData');
           shell.openItem(userDataPath);
         }
       },
       {
-        label: Labels.ClearCacheAndReload,
+        label: s().clearCacheAndReload,
         async click() {
           await window.webContents.session.clearCache();
           window.reload();
@@ -595,7 +532,7 @@ function helpMenu(window: Electron.BrowserWindow, shell: Electron.Shell) {
       },
       Separator,
       {
-        label: Labels.version(app.getVersion()),
+        label: s().version(app.getVersion()),
         click() {
           shell.openExternal(Urls.GitHubReleases);
         }

--- a/app/javascripts/main/menuManager.ts
+++ b/app/javascripts/main/menuManager.ts
@@ -5,7 +5,7 @@ import { TrayManager } from './trayManager';
 import { SpellcheckerManager } from './spellcheckerManager';
 import { MenuItemConstructorOptions, app, Menu, dialog, shell } from 'electron';
 import { isMac } from './platforms';
-import { appMenu as s } from './strings';
+import { appMenu as str } from './strings';
 
 export function createMenuManager({
   window,
@@ -36,7 +36,7 @@ export function createMenuManager({
     ]);
     Menu.setApplicationMenu(menu);
   }
-  reload() // initialization
+  reload(); // initialization
 
   updateManager.onNeedMenuReload = reload;
 
@@ -141,7 +141,7 @@ function editMenu(
   reload: () => any
 ): MenuItemConstructorOptions {
   return {
-    label: s().edit,
+    label: str().edit,
     submenu: [
       {
         role: Roles.Undo
@@ -174,7 +174,7 @@ function editMenu(
 
 function macSpeechMenu(): MenuItemConstructorOptions {
   return {
-    label: s().speech,
+    label: str().speech,
     submenu: [
       {
         role: Roles.StopSeeking
@@ -191,7 +191,7 @@ function spellcheckerMenu(
   reload: () => any
 ): MenuItemConstructorOptions {
   return {
-    label: s().spellcheckerLanguages,
+    label: str().spellcheckerLanguages,
     submenu: spellcheckerManager.languages().map(
       ({ name, code, enabled }): MenuItemConstructorOptions => {
         return {
@@ -218,7 +218,7 @@ function viewMenu(
   reload: () => any
 ): MenuItemConstructorOptions {
   return {
-    label: s().view,
+    label: str().view,
     submenu: [
       {
         role: Roles.Reload
@@ -256,7 +256,7 @@ function menuBarOptions(
   return [
     {
       visible: !isMac && useSystemMenuBar,
-      label: s().hideMenuBar,
+      label: str().hideMenuBar,
       accelerator: KeyCombinations.AltM,
       click: () => {
         isMenuBarVisible = !isMenuBarVisible;
@@ -265,22 +265,26 @@ function menuBarOptions(
       }
     },
     {
-      label: s().useThemedMenuBar,
+      label: str().useThemedMenuBar,
       type: MenuItemTypes.CheckBox,
       checked: !useSystemMenuBar,
       click: () => {
         store.set(StoreKeys.UseSystemMenuBar, !useSystemMenuBar);
         reload();
         dialog.showMessageBox({
-          title: s().preferencesChanged.title,
-          message: s().preferencesChanged.message
+          title: str().preferencesChanged.title,
+          message: str().preferencesChanged.message
         });
       }
     }
   ];
 }
 
-function windowMenu(store: Store, trayManager: TrayManager, reload: () => any): MenuItemConstructorOptions {
+function windowMenu(
+  store: Store,
+  trayManager: TrayManager,
+  reload: () => any
+): MenuItemConstructorOptions {
   return {
     role: Roles.Window,
     submenu: [
@@ -301,22 +305,22 @@ function windowMenu(store: Store, trayManager: TrayManager, reload: () => any): 
 function macWindowItems(): MenuItemConstructorOptions[] {
   return [
     {
-      label: s().close,
+      label: str().close,
       accelerator: KeyCombinations.CmdOrCtrlW,
       role: Roles.Close
     },
     {
-      label: s().minimize,
+      label: str().minimize,
       accelerator: KeyCombinations.CmdOrCtrlM,
       role: Roles.Minimize
     },
     {
-      label: s().zoom,
+      label: str().zoom,
       role: Roles.Zoom
     },
     Separator,
     {
-      label: s().bringAllToFront,
+      label: str().bringAllToFront,
       role: Roles.Front
     }
   ];
@@ -329,7 +333,7 @@ function minimizeToTrayItem(
 ) {
   const minimizeToTray = trayManager.shouldMinimizeToTray();
   return {
-    label: s().minimizeToTrayOnClose,
+    label: str().minimizeToTrayOnClose,
     type: MenuItemTypes.CheckBox,
     checked: minimizeToTray,
     click() {
@@ -346,12 +350,12 @@ function minimizeToTrayItem(
 
 function backupsMenu(archiveManager: ArchiveManager, reload: () => any) {
   return {
-    label: s().backups,
+    label: str().backups,
     submenu: [
       {
         label: archiveManager.isBackupsEnabled()
-          ? s().disableAutomaticBackups
-          : s().enableAutomaticBackups,
+          ? str().disableAutomaticBackups
+          : str().enableAutomaticBackups,
         click() {
           archiveManager.toggleBackupsStatus();
           reload();
@@ -359,13 +363,13 @@ function backupsMenu(archiveManager: ArchiveManager, reload: () => any) {
       },
       Separator,
       {
-        label: s().changeBackupsLocation,
+        label: str().changeBackupsLocation,
         click() {
           archiveManager.changeBackupsLocation();
         }
       },
       {
-        label: s().openBackupsLocation,
+        label: str().openBackupsLocation,
         click() {
           shell.openItem(archiveManager.getBackupsLocation());
         }
@@ -379,18 +383,18 @@ function updateMenu(updateManager: UpdateManager) {
   const updateNeeded = updateManager.updateNeeded();
   let label;
   if (updateData.checkingForUpdate) {
-    label = s().checkingForUpdate;
+    label = str().checkingForUpdate;
   } else if (updateNeeded) {
-    label = s().updateAvailable;
+    label = str().updateAvailable;
   } else {
-    label = s().updates;
+    label = str().updates;
   }
   const submenu: MenuItemConstructorOptions[] = [];
   const structure = { label, submenu };
 
   if (updateManager.autoupdateDownloaded()) {
     submenu.push({
-      label: s().installPendingUpdate(
+      label: str().installPendingUpdate(
         updateManager.autoupdateDownloadedVersion()
       ),
       click() {
@@ -401,8 +405,8 @@ function updateMenu(updateManager: UpdateManager) {
 
   submenu.push({
     label: updateManager.autoupdateEnabled()
-      ? s().automaticUpdatesEnabled
-      : s().automaticUpdatesDisabled,
+      ? str().automaticUpdatesEnabled
+      : str().automaticUpdatesDisabled,
     click() {
       updateManager.toggleAutoupdateStatus();
     }
@@ -412,14 +416,14 @@ function updateMenu(updateManager: UpdateManager) {
 
   if (updateData.lastCheck && !updateData.checkinForUpdate) {
     submenu.push({
-      label: s().lastUpdateCheck(updateData.lastCheck),
+      label: str().lastUpdateCheck(updateData.lastCheck),
       click: () => {}
     });
   }
 
   if (!updateData.checkinForUpdate) {
     submenu.push({
-      label: s().checkForUpdate,
+      label: str().checkForUpdate,
       click: () => {
         updateManager.checkForUpdate({ userTriggered: true });
       }
@@ -429,15 +433,15 @@ function updateMenu(updateManager: UpdateManager) {
   submenu.push(Separator);
 
   submenu.push({
-    label: s().yourVersion(updateData.currentVersion),
+    label: str().yourVersion(updateData.currentVersion),
     click: () => {}
   });
 
   const latestVersion = updateManager.latestVersion();
   submenu.push({
     label: latestVersion
-      ? s().latestVersion(latestVersion)
-      : s().errorRetrieving,
+      ? str().latestVersion(latestVersion)
+      : str().errorRetrieving,
     click() {
       updateManager.openChangelog();
     }
@@ -446,7 +450,7 @@ function updateMenu(updateManager: UpdateManager) {
   submenu.push(Separator);
 
   submenu.push({
-    label: s().viewReleaseNotes(latestVersion),
+    label: str().viewReleaseNotes(latestVersion),
     click() {
       updateManager.openChangelog();
     }
@@ -454,7 +458,7 @@ function updateMenu(updateManager: UpdateManager) {
 
   if (updateData.latestDownloaded) {
     submenu.push({
-      label: s().openDownloadLocation,
+      label: str().openDownloadLocation,
       click() {
         updateManager.openDownloadLocation();
       }
@@ -462,8 +466,8 @@ function updateMenu(updateManager: UpdateManager) {
   } else if (updateNeeded || updateData.downloadingUpdate) {
     submenu.push({
       label: updateData.downloadingUpdate
-        ? s().downloadingUpdate
-        : s().manuallyDownloadUpdate,
+        ? str().downloadingUpdate
+        : str().manuallyDownloadUpdate,
       click() {
         updateData.downloadingUpdate
           ? updateManager.openDownloadLocation()
@@ -480,51 +484,51 @@ function helpMenu(window: Electron.BrowserWindow, shell: Electron.Shell) {
     role: Roles.Help,
     submenu: [
       {
-        label: s().emailSupport,
+        label: str().emailSupport,
         click() {
           shell.openExternal(Urls.Support);
         }
       },
       {
-        label: s().website,
+        label: str().website,
         click() {
           shell.openExternal(Urls.Website);
         }
       },
       {
-        label: s().gitHub,
+        label: str().gitHub,
         click() {
           shell.openExternal(Urls.GitHub);
         }
       },
       {
-        label: s().slack,
+        label: str().slack,
         click() {
           shell.openExternal(Urls.Slack);
         }
       },
       {
-        label: s().twitter,
+        label: str().twitter,
         click() {
           shell.openExternal(Urls.Twitter);
         }
       },
       Separator,
       {
-        label: s().toggleErrorConsole,
+        label: str().toggleErrorConsole,
         click() {
           window.webContents.toggleDevTools();
         }
       },
       {
-        label: s().openDataDirectory,
+        label: str().openDataDirectory,
         click() {
           const userDataPath = app.getPath('userData');
           shell.openItem(userDataPath);
         }
       },
       {
-        label: s().clearCacheAndReload,
+        label: str().clearCacheAndReload,
         async click() {
           await window.webContents.session.clearCache();
           window.reload();
@@ -532,7 +536,7 @@ function helpMenu(window: Electron.BrowserWindow, shell: Electron.Shell) {
       },
       Separator,
       {
-        label: s().version(app.getVersion()),
+        label: str().version(app.getVersion()),
         click() {
           shell.openExternal(Urls.GitHubReleases);
         }

--- a/app/javascripts/main/strings.ts
+++ b/app/javascripts/main/strings.ts
@@ -1,8 +1,0 @@
-export const AppName = 'Standard Notes';
-export const TrayLabelShow = 'Show';
-export const TrayLabelHide = 'Hide';
-export const TrayLabelQuit = 'Quit';
-
-export const UnableToLoadExtension =
-  'Unable to load extension. Please restart the application and try again. ' +
-  'If the issue persists, try uninstalling then reinstalling the extension.';

--- a/app/javascripts/main/strings/english.ts
+++ b/app/javascripts/main/strings/english.ts
@@ -1,0 +1,77 @@
+import { Strings } from './types';
+
+export function createEnglishStrings(): Strings {
+  return {
+    appMenu: {
+      edit: 'Edit',
+      view: 'View',
+      hideMenuBar: 'Hide Menu Bar',
+      useThemedMenuBar: 'Use Themed Menu Bar',
+      minimizeToTrayOnClose: 'Minimize To Tray On Close',
+      backups: 'Backups',
+      automaticUpdatesEnabled: 'Automatic Updates Enabled',
+      automaticUpdatesDisabled: 'Automatic Updates Disabled',
+      disableAutomaticBackups: 'Disable Automatic Backups',
+      enableAutomaticBackups: 'Enable Automatic Backups',
+      changeBackupsLocation: 'Change Backups Location',
+      openBackupsLocation: 'Open Backups Location',
+      emailSupport: 'Email Support',
+      website: 'Website',
+      gitHub: 'GitHub',
+      slack: 'Slack',
+      twitter: 'Twitter',
+      toggleErrorConsole: 'Toggle Error Console',
+      openDataDirectory: 'Open Data Directory',
+      clearCacheAndReload: 'Clear Cache and Reload',
+      speech: 'Speech',
+      close: 'Close',
+      minimize: 'Minimize',
+      zoom: 'Zoom',
+      bringAllToFront: 'Bring All to Front',
+      checkForUpdate: 'Check for Update',
+      checkingForUpdate: 'Checking for update…',
+      updateAvailable: '(1) Update Available',
+      updates: 'Updates',
+      errorRetrieving: 'Error Retrieving',
+      openDownloadLocation: 'Open Download Location',
+      downloadingUpdate: 'Downloading Update…',
+      manuallyDownloadUpdate: 'Manually Download Update',
+      spellcheckerLanguages: 'Spellchecker Languages',
+      installPendingUpdate(versionNumber: string) {
+        return `Install Pending Update (${versionNumber})`;
+      },
+      lastUpdateCheck(date: Date) {
+        return `Last checked ${date.toLocaleString()}`;
+      },
+      version(number: string) {
+        return `Version: ${number}`;
+      },
+      yourVersion(number: string) {
+        return `Your Version: ${number}`;
+      },
+      latestVersion(number: string) {
+        return `Latest Version: ${number}`;
+      },
+      viewReleaseNotes(versionNumber: string) {
+        return `View ${versionNumber} Release Notes`;
+      },
+      preferencesChanged: {
+        title: 'Preference Changed',
+        message:
+          'Your menu bar preference has been saved. Please restart the ' +
+          'application for the change to take effect.'
+      }
+    },
+    tray: {
+      show: 'Show',
+      hide: 'Hide',
+      quit: 'Quit'
+    },
+    extensions: {
+      unableToLoadExtension:
+        'Unable to load extension. Please restart the application and ' +
+        'try again. If the issue persists, try uninstalling then ' +
+        'reinstalling the extension.'
+    }
+  };
+}

--- a/app/javascripts/main/strings/french.ts
+++ b/app/javascripts/main/strings/french.ts
@@ -1,0 +1,26 @@
+import { Strings } from './types';
+import { createEnglishStrings } from './english';
+
+export function createFrenchStrings(): Strings {
+  const fallback = createEnglishStrings();
+  if (process.env.NODE_ENV !== 'development') {
+    /**
+     * Le Français est une langue expérimentale.
+     * Don't show it in production yet.
+     */
+    return fallback;
+  }
+  return {
+    appMenu: {
+      ...fallback.appMenu,
+      edit: 'Édition',
+      view: 'Affichage',
+    },
+    tray: {
+      show: 'Afficher',
+      hide: 'Masquer',
+      quit: 'Quitter'
+    },
+    extensions: fallback.extensions
+  };
+}

--- a/app/javascripts/main/strings/index.ts
+++ b/app/javascripts/main/strings/index.ts
@@ -1,0 +1,53 @@
+import { createEnglishStrings } from './english';
+import { createFrenchStrings } from './french';
+import { Strings } from './types';
+
+let strings: Strings;
+
+/**
+ * MUST be called (once) before using any other export in this file.
+ * @param locale The user's locale
+ * @see https://www.electronjs.org/docs/api/locales
+ */
+export function initializeStrings(locale: string) {
+  if (process.env.NODE_ENV === 'development') {
+    if (strings) {
+      throw new Error('`strings` has already been initialized');
+    }
+  }
+  if (strings) return;
+  strings = stringsForLocale(locale);
+}
+
+export function s(): Strings {
+  if (process.env.NODE_ENV === 'development') {
+    if (!strings) {
+      throw new Error('tried to access strings before they were initialized.');
+    }
+  }
+  return strings;
+}
+
+export function appMenu() {
+  return s().appMenu;
+}
+
+export function tray() {
+  return s().tray;
+}
+
+export function extensions() {
+  return s().extensions;
+}
+
+function stringsForLocale(locale: string): Strings {
+  if (locale === 'en' || locale.startsWith('en-')) {
+    return createEnglishStrings();
+  } else if (locale === 'fr' || locale.startsWith('fr-')) {
+    return createFrenchStrings();
+  }
+
+  return createEnglishStrings();
+}
+
+export const AppName = 'Standard Notes';

--- a/app/javascripts/main/strings/index.ts
+++ b/app/javascripts/main/strings/index.ts
@@ -19,7 +19,7 @@ export function initializeStrings(locale: string) {
   strings = stringsForLocale(locale);
 }
 
-export function s(): Strings {
+export function str(): Strings {
   if (process.env.NODE_ENV === 'development') {
     if (!strings) {
       throw new Error('tried to access strings before they were initialized.');
@@ -29,15 +29,15 @@ export function s(): Strings {
 }
 
 export function appMenu() {
-  return s().appMenu;
+  return str().appMenu;
 }
 
 export function tray() {
-  return s().tray;
+  return str().tray;
 }
 
 export function extensions() {
-  return s().extensions;
+  return str().extensions;
 }
 
 function stringsForLocale(locale: string): Strings {

--- a/app/javascripts/main/strings/types.ts
+++ b/app/javascripts/main/strings/types.ts
@@ -1,0 +1,62 @@
+export interface Strings {
+  readonly appMenu: Readonly<AppMenuStrings>;
+  readonly tray: Readonly<TrayStrings>;
+  readonly extensions: Readonly<ExtensionsStrings>;
+}
+
+interface AppMenuStrings {
+  edit: string;
+  view: string;
+  hideMenuBar: string;
+  useThemedMenuBar: string;
+  minimizeToTrayOnClose: string;
+  backups: string;
+  automaticUpdatesEnabled: string;
+  automaticUpdatesDisabled: string;
+  disableAutomaticBackups: string;
+  enableAutomaticBackups: string;
+  changeBackupsLocation: string;
+  openBackupsLocation: string;
+  emailSupport: string;
+  website: string;
+  gitHub: string;
+  slack: string;
+  twitter: string;
+  toggleErrorConsole: string;
+  openDataDirectory: string;
+  clearCacheAndReload: string;
+  speech: string;
+  close: string;
+  minimize: string;
+  zoom: string;
+  bringAllToFront: string;
+  checkForUpdate: string;
+  checkingForUpdate: string;
+  updateAvailable: string;
+  updates: string;
+  errorRetrieving: string;
+  openDownloadLocation: string;
+  downloadingUpdate: string;
+  manuallyDownloadUpdate: string;
+  spellcheckerLanguages: string;
+  installPendingUpdate(versionNumber: string): string;
+  lastUpdateCheck(date: Date): string;
+  version(number: string): string;
+  yourVersion(number: string): string;
+  latestVersion(number: string): string;
+  viewReleaseNotes(versionNumber: string): string;
+  preferencesChanged: {
+    title: string;
+    message: string;
+  };
+}
+
+interface TrayStrings {
+  show: string;
+  hide: string;
+  quit: string;
+}
+
+interface ExtensionsStrings {
+  unableToLoadExtension: string
+}

--- a/app/javascripts/main/trayManager.ts
+++ b/app/javascripts/main/trayManager.ts
@@ -2,7 +2,7 @@ import { Menu, Tray } from 'electron';
 import path from 'path';
 import { isLinux, isWindows } from './platforms';
 import { Store, StoreKeys } from './store';
-import { AppName, tray as s } from './strings';
+import { AppName, tray as str } from './strings';
 
 const icon = path.join(__dirname, '/icon/Icon-256x256.png');
 
@@ -52,12 +52,12 @@ export function createTrayManager(
       const trayContextMenu = Menu.buildFromTemplate([
         {
           id: SHOW_WINDOW_ID,
-          label: s().show,
+          label: str().show,
           click: showWindow
         },
         {
           id: HIDE_WINDOW_ID,
-          label: s().hide,
+          label: str().hide,
           click() {
             window.hide();
           }
@@ -67,7 +67,7 @@ export function createTrayManager(
         },
         {
           role: 'quit',
-          label: s().quit
+          label: str().quit
         }
       ]);
 

--- a/app/javascripts/main/trayManager.ts
+++ b/app/javascripts/main/trayManager.ts
@@ -52,12 +52,12 @@ export function createTrayManager(
       const trayContextMenu = Menu.buildFromTemplate([
         {
           id: SHOW_WINDOW_ID,
-          label: TrayLabelShow,
+          label: s().show,
           click: showWindow
         },
         {
           id: HIDE_WINDOW_ID,
-          label: TrayLabelHide,
+          label: s().hide,
           click() {
             window.hide();
           }
@@ -66,10 +66,8 @@ export function createTrayManager(
           type: 'separator'
         },
         {
-          label: TrayLabelQuit,
-          click() {
-            app.quit();
-          }
+          role: 'quit',
+          label: s().quit
         }
       ]);
 


### PR DESCRIPTION
Introduce a system to enable localization in the desktop part of the app.
Plain objects with associated type definitions and global exports give us:
- Safety (TypeScript)
- Namespacing (nested objects)
- Straightforwardness in understanding: it's just functions and objects. Everything needed for understanding this part of the app is in the `strings` folder
- Straightforwardness in composition (see `french.ts` for an example of using fallback text`)
- Customizability: functions take arguments and output strings
- Relative ease of modification: might not be as good as a YAML file but on the other hand there's no custom grammar we have to tell people to look out for.
- Ease of use: all the app's strings are an import and an ~~`s()`~~ `str()` away