### PR TITLE
Switch to ts-loader

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,6 @@ module.exports = function (api) {
   api.cache(true);
 
   const presets = [
-    "@babel/typescript",
     [
       "@babel/preset-env", {
       "targets": {
@@ -12,7 +11,6 @@ module.exports = function (api) {
   ];
 
   const plugins = [
-    "const-enum",
     "@babel/plugin-proposal-class-properties"
   ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,15 +1046,6 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
-    "@babel/plugin-syntax-typescript": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.3.tgz",
-      "integrity": "sha512-GO1MQ/SGGGoiEXY0e0bSpHimJvxqB7lktLLIq2pv8xG7WZ8IMEle74jIe1FhprHBWjwjZtXHkycDLZXIWM5Wfg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      }
-    },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
@@ -1351,17 +1342,6 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
-    "@babel/plugin-transform-typescript": {
-      "version": "7.9.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.4.tgz",
-      "integrity": "sha512-yeWeUkKx2auDbSxRe8MusAG+n4m9BFY/v+lPjmQDgOFX5qnySkUY5oXzkp6FwPdsYqnKay6lorXYdC0n3bZO7w==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-typescript": "^7.8.3"
-      }
-    },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
@@ -1451,16 +1431,6 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
-      }
-    },
-    "@babel/preset-typescript": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.9.0.tgz",
-      "integrity": "sha512-S4cueFnGrIbvYJgwsVFKdvOmpiL0XGw9MFW9D0vgRys5g36PBhZRL8NX8Gr2akz8XRtzq6HuDXPD/1nniagNUg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-transform-typescript": "^7.9.0"
       }
     },
     "@babel/runtime": {
@@ -2601,16 +2571,6 @@
             "ajv-keywords": "^3.4.1"
           }
         }
-      }
-    },
-    "babel-plugin-const-enum": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-const-enum/-/babel-plugin-const-enum-0.0.5.tgz",
-      "integrity": "sha512-EAOnmHcsn+hbMS1yYZoc0jBemNbRR+NATO9RrLJF/1iXJbDTEaOwH0Y7XPb7vvWc5C/nHp7v8WhAsHW7UjxYQA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-typescript": "^7.3.3"
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -10418,6 +10378,70 @@
       "dev": true,
       "requires": {
         "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "ts-loader": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
+      "integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "enhanced-resolve": "^4.0.0",
+        "loader-utils": "^1.0.2",
+        "micromatch": "^4.0.0",
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "ts-mocha": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@babel/core": "^7.9.0",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/preset-env": "^7.9.0",
-    "@babel/preset-typescript": "^7.9.0",
     "@types/mime-types": "^2.1.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.12.30",
@@ -20,7 +19,6 @@
     "@typescript-eslint/parser": "^2.26.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
-    "babel-plugin-const-enum": "0.0.5",
     "copy-webpack-plugin": "^5.1.1",
     "electron": "^8.2.0",
     "electron-builder": "^22.4.1",
@@ -40,6 +38,7 @@
     "mocha": "^7.1.1",
     "rimraf": "^3.0.2",
     "spectron": "^10.0.1",
+    "ts-loader": "^6.2.2",
     "ts-mocha": "^7.0.0",
     "typescript": "^3.8.3",
     "webpack": "^4.42.1",
@@ -107,6 +106,6 @@
     "setup": "npm install && npm --prefix ./app install ./app && git submodule update --init --force --remote",
     "lint": "eslint app/index.ts app/application.ts app/javascripts/**/*.ts test/*.ts",
     "test": "ts-mocha test/*.ts",
-    "check-types": "tsc"
+    "check-types": "tsc --noEmit"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,14 @@
 {
   "compilerOptions": {
-    /** Target latest version of ECMAScript. */
-    "target": "esnext",
+    "target": "ESNext",
     /** Search under node_modules for non-relative imports. */
     "moduleResolution": "node",
     /** Process & infer types from .js files. */
     "allowJs": true,
-    /** Don't emit; allow Babel to transform files. */
-    "noEmit": true,
+
+    "sourceMap": true,
     /** Enable strictest settings like strictNullChecks & noImplicitAny. */
     "strict": true,
-    /** Disallow features that require cross-file information for emit. */
-    "isolatedModules": true,
     /** Import non-ES modules as default imports. */
     "esModuleInterop": true,
     "typeRoots" : ["./app/@types"]

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,80 +1,97 @@
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 
-const moduleConfig = {
-  rules: [
-    {
-      test: /\.(js|ts)$/,
-      exclude: /node_modules/,
-      loader: 'babel-loader'
-    },
-    {
-      test: /\.(png|html)$/i,
-      loader: 'file-loader',
-      options: {
-        name: '[name].[ext]'
+module.exports = function({ onlyTranspileTypescript = false } = {}) {
+  const moduleConfig = {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        exclude: /node_modules/,
+        use: [
+          'babel-loader',
+          {
+            loader: 'ts-loader',
+            options: {
+              transpileOnly: onlyTranspileTypescript
+            }
+          }
+        ]
+      },
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader'
+      },
+      {
+        test: /\.(png|html)$/i,
+        loader: 'file-loader',
+        options: {
+          name: '[name].[ext]'
+        }
       }
+    ]
+  };
+
+  const resolve = {
+    extensions: ['.ts', '.js']
+  };
+
+  const electronMainConfig = {
+    entry: {
+      index: './app/index.ts'
+    },
+    output: {
+      path: path.resolve(__dirname, 'app', 'dist'),
+      filename: 'index.js'
+    },
+    devtool: 'inline-cheap-source-map',
+    target: 'electron-main',
+    node: {
+      __dirname: false
+    },
+    resolve,
+    module: moduleConfig,
+    plugins: [
+      new CopyPlugin([
+        { from: 'app/extensions', to: 'extensions' },
+        { from: 'app/vendor', to: 'vendor' },
+        {
+          from: 'app/node_modules/standard-notes-web/dist',
+          to: 'standard-notes-web'
+        },
+        {
+          from: 'app/node_modules/sn-electron-valence',
+          to: 'sn-electron-valence'
+        },
+        {
+          from: 'app/stylesheets/renderer.css',
+          to: 'stylesheets/renderer.css'
+        },
+        { from: 'app/icon', to: 'icon' }
+      ])
+    ]
+  };
+
+  const electronRendererConfig = {
+    entry: {
+      preload: './app/javascripts/renderer/preload.js',
+      renderer: './app/javascripts/renderer/renderer.js'
+    },
+    output: {
+      path: path.resolve(__dirname, 'app', 'dist', 'javascripts', 'renderer')
+    },
+    target: 'electron-renderer',
+    devtool: 'inline-cheap-source-map',
+    node: {
+      __dirname: false
+    },
+    resolve,
+    module: moduleConfig,
+    externals: {
+      electron: 'commonjs electron',
+      'sn-electron-valence/Transmitter':
+        'commonjs sn-electron-valence/Transmitter'
     }
-  ]
+  };
+  return [electronMainConfig, electronRendererConfig];
 };
-
-const resolve = {
-  extensions: ['.ts', '.js']
-};
-
-const electronMainConfig = {
-  entry: {
-    index: './app/index.ts'
-  },
-  output: {
-    path: path.resolve(__dirname, 'app', 'dist'),
-    filename: 'index.js'
-  },
-  devtool: 'inline-cheap-source-map',
-  target: 'electron-main',
-  node: {
-    __dirname: false
-  },
-  resolve,
-  module: moduleConfig,
-  plugins: [
-    new CopyPlugin([
-      { from: 'app/extensions', to: 'extensions' },
-      { from: 'app/vendor', to: 'vendor' },
-      {
-        from: 'app/node_modules/standard-notes-web/dist',
-        to: 'standard-notes-web'
-      },
-      {
-        from: 'app/node_modules/sn-electron-valence',
-        to: 'sn-electron-valence'
-      },
-      { from: 'app/stylesheets/renderer.css', to: 'stylesheets/renderer.css' },
-      { from: 'app/icon', to: 'icon' }
-    ])
-  ]
-};
-
-const electronRendererConfig = {
-  entry: {
-    preload: './app/javascripts/renderer/preload.js',
-    renderer: './app/javascripts/renderer/renderer.js'
-  },
-  output: {
-    path: path.resolve(__dirname, 'app', 'dist', 'javascripts', 'renderer')
-  },
-  target: 'electron-renderer',
-  devtool: 'inline-cheap-source-map',
-  node: {
-    __dirname: false
-  },
-  resolve,
-  module: moduleConfig,
-  externals: {
-    electron: 'commonjs electron',
-    'sn-electron-valence/Transmitter':
-      'commonjs sn-electron-valence/Transmitter'
-  }
-};
-
-module.exports = [electronMainConfig, electronRendererConfig];

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,7 +1,7 @@
 const merge = require("webpack-merge");
 const common = require("./webpack.common.js");
 
-module.exports = common.map(config =>
+module.exports = common({ onlyTranspileTypescript: true }).map(config =>
   merge(config, {
     mode: "development",
     devtool: "inline-cheap-source-map"

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,7 +1,7 @@
 const merge = require("webpack-merge");
 const common = require("./webpack.common.js");
 
-module.exports = common.map(config =>
+module.exports = common().map(config =>
   merge(config, {
     mode: "production",
     devtool: "source-map"


### PR DESCRIPTION
We can actually get the same speed as the babel plugin if we use ts-loader's option to only transpile files in dev mode (and not do any type checking.) 
During a full build, we can then enable said type-checking to get an extra level of safety (we don't have to remember to run `npm run check-types`.)
Also the babel plugin has some limitations, like not being able to optimize `const enum`s. But we could use those, so here we are :)