### PR TITLE
Add tests for the store

### DIFF
--- a/app/application.ts
+++ b/app/application.ts
@@ -23,9 +23,8 @@ export function initializeApplication(args: {
   app: Electron.App;
   ipcMain: Electron.IpcMain;
   shell: Shell;
-  store: Store;
 }) {
-  const { app, store } = args;
+  const { app } = args;
 
   app.name = AppName;
   app.allowRendererProcessReuse = true;
@@ -33,7 +32,7 @@ export function initializeApplication(args: {
   const isPrimaryInstance = app.requestSingleInstanceLock();
 
   const state: AppState = {
-    store,
+    store: new Store(app.getPath('userData')),
     startUrl: determineStartUrl(),
     isPrimaryInstance,
     willQuitApp: false
@@ -43,6 +42,11 @@ export function initializeApplication(args: {
     ...args,
     state
   });
+
+  if (process.env.NODE_ENV === 'development') {
+    /** Expose the app's state as a global variable. Useful for debugging */
+    (global as any).appState = state;
+  }
 }
 
 function determineStartUrl(): string {

--- a/app/application.ts
+++ b/app/application.ts
@@ -9,6 +9,7 @@ import { Store, StoreKeys } from './javascripts/main/store';
 import { AppName, initializeStrings } from './javascripts/main/strings';
 import { createWindowState, WindowState } from './javascripts/main/window';
 import { IpcMessages } from './javascripts/shared/ipcMessages';
+import { isDev } from './javascripts/main/utils';
 
 export interface AppState {
   readonly store: Store;
@@ -43,7 +44,7 @@ export function initializeApplication(args: {
     state
   });
 
-  if (process.env.NODE_ENV === 'development') {
+  if (isDev()) {
     /** Expose the app's state as a global variable. Useful for debugging */
     (global as any).appState = state;
   }

--- a/app/index.ts
+++ b/app/index.ts
@@ -1,7 +1,6 @@
+import { app, ipcMain, shell } from 'electron';
 import log from 'electron-log';
-import { app, shell, ipcMain } from 'electron';
 import { initializeApplication } from './application';
-import { Store } from './javascripts/main/store';
 
 log.transports.file.level = 'info';
 

--- a/app/index.ts
+++ b/app/index.ts
@@ -12,6 +12,5 @@ process.on('uncaughtException', err => {
 initializeApplication({
   app,
   shell,
-  ipcMain,
-  store: Store.getInstance()
+  ipcMain
 });

--- a/app/javascripts/main/archiveManager.ts
+++ b/app/javascripts/main/archiveManager.ts
@@ -1,4 +1,4 @@
-import { app, dialog, IpcMain, WebContents } from 'electron';
+import { dialog, IpcMain, WebContents } from 'electron';
 import fs from 'fs';
 import path from 'path';
 import { IpcMessages } from '../shared/ipcMessages';
@@ -11,7 +11,7 @@ function log(...message: any) {
 
 function logError(...message: any) {
   console.error('archiveManager:', ...message);
-};
+}
 
 export interface ArchiveManager {
   backupsAreEnabled: boolean;

--- a/app/javascripts/main/archiveManager.ts
+++ b/app/javascripts/main/archiveManager.ts
@@ -11,12 +11,7 @@ function log(...message: any) {
 
 function logError(...message: any) {
   console.error('archiveManager:', ...message);
-}
-
-const defaultLocation = path.join(
-  app.getPath('home'),
-  'Standard Notes Backups'
-);
+};
 
 export interface ArchiveManager {
   backupsAreEnabled: boolean;
@@ -33,8 +28,8 @@ export function createArchiveManager(
   store: Store,
   ipcMain: IpcMain
 ): ArchiveManager {
-  let backupsLocation = store.get(StoreKeys.BackupsLocation) || defaultLocation;
-  let backupsDisabled = store.get(StoreKeys.BackupsDisabled) ?? false;
+  let backupsLocation = store.get(StoreKeys.BackupsLocation);
+  let backupsDisabled = store.get(StoreKeys.BackupsDisabled);
   let needsBackup = false;
 
   ipcMain.on(IpcMessages.DataArchive, async (_event, data) => {

--- a/app/javascripts/main/menuManager.ts
+++ b/app/javascripts/main/menuManager.ts
@@ -6,6 +6,7 @@ import { SpellcheckerManager } from './spellcheckerManager';
 import { MenuItemConstructorOptions, app, Menu, dialog, shell } from 'electron';
 import { isMac } from './platforms';
 import { appMenu as str } from './strings';
+import { isDev } from './utils';
 
 export interface MenuManager {
   reload(): void;
@@ -48,7 +49,7 @@ export function createMenuManager({
   return {
     reload,
     popupMenu() {
-      if (process.env.NODE_ENV === 'development') {
+      if (isDev()) {
         /** Check the state */
         if (!menu) throw new Error('called popupMenu() before loading');
       }
@@ -146,7 +147,7 @@ function editMenu(
   spellcheckerManager: SpellcheckerManager | undefined,
   reload: () => any
 ): MenuItemConstructorOptions {
-  if (process.env.NODE_ENV === 'development') {
+  if (isDev()) {
     /** Check for invalid state */
     if (!isMac && spellcheckerManager === undefined) {
       throw new Error('spellcheckerManager === undefined');

--- a/app/javascripts/main/spellcheckerManager.ts
+++ b/app/javascripts/main/spellcheckerManager.ts
@@ -175,9 +175,7 @@ export function createSpellcheckerManager(
   ) {
     /** This means that not every available language has been accounted for. */
     const firstOutlier = session.availableSpellCheckerLanguages.find(
-      (language, index) => {
-        availableSpellCheckerLanguages[index] !== language;
-      }
+      (language, index) => availableSpellCheckerLanguages[index] !== language
     );
     throw new Error(`Found unsupported language code: ${firstOutlier}`);
   }

--- a/app/javascripts/main/spellcheckerManager.ts
+++ b/app/javascripts/main/spellcheckerManager.ts
@@ -1,6 +1,7 @@
 import buildEditorContextMenu from 'electron-editor-context-menu';
 import { Store, StoreKeys } from './store';
 import { isMac } from './platforms';
+import { isDev } from './utils';
 
 export enum Language {
   AF = 'af',
@@ -168,7 +169,7 @@ export function createSpellcheckerManager(
   );
 
   if (
-    process.env.NODE_ENV === 'development' &&
+    isDev() &&
     availableSpellCheckerLanguages.length !==
       session.availableSpellCheckerLanguages.length
   ) {

--- a/app/javascripts/main/store.ts
+++ b/app/javascripts/main/store.ts
@@ -1,6 +1,13 @@
-import electron from 'electron';
+import { app, remote, ipcMain, App } from 'electron';
 import fs from 'fs';
 import path from 'path';
+import { Language } from './spellcheckerManager';
+import { isTesting } from './utils';
+import { TestIpcMessages } from '../../../test/TestIpcMessages';
+
+function logError(...message: any) {
+  console.error('store:', ...message);
+}
 
 export enum StoreKeys {
   ExtServerHost = 'extServerHost',
@@ -10,15 +17,115 @@ export enum StoreKeys {
   BackupsDisabled = 'backupsDisabled',
   MinimizeToTray = 'minimizeToTray',
   ZoomFactor = 'zoomFactor',
-  /**
-   * @type {Set<String> | null} a set of language codes.
-   */
   SelectedSpellCheckerLanguageCodes = 'selectedSpellCheckerLanguageCodes'
-};
+}
 
-type StoreData = {
-  [key in StoreKeys]?: any;
-};
+interface StoreData {
+  [StoreKeys.ExtServerHost]: string | null;
+  [StoreKeys.UseSystemMenuBar]: boolean;
+  [StoreKeys.MenuBarVisible]: boolean;
+  [StoreKeys.BackupsLocation]: string;
+  [StoreKeys.BackupsDisabled]: boolean;
+  [StoreKeys.MinimizeToTray]: boolean;
+  [StoreKeys.ZoomFactor]: number;
+  [StoreKeys.SelectedSpellCheckerLanguageCodes]: Set<Language> | null;
+}
+
+function createSanitizedStoreData(data: any = {}): StoreData {
+  return {
+    [StoreKeys.MenuBarVisible]:
+      typeof data[StoreKeys.MenuBarVisible] === 'boolean'
+        ? data[StoreKeys.MenuBarVisible]
+        : true,
+    [StoreKeys.UseSystemMenuBar]:
+      typeof data[StoreKeys.UseSystemMenuBar] === 'boolean'
+        ? data[StoreKeys.UseSystemMenuBar]
+        : false,
+    [StoreKeys.BackupsDisabled]:
+      typeof data[StoreKeys.BackupsDisabled] === 'boolean'
+        ? data[StoreKeys.BackupsDisabled]
+        : false,
+    [StoreKeys.MinimizeToTray]:
+      typeof data[StoreKeys.MinimizeToTray] === 'boolean'
+        ? data[StoreKeys.MinimizeToTray]
+        : false,
+    [StoreKeys.ExtServerHost]:
+      typeof data[StoreKeys.ExtServerHost] === 'string'
+        ? data[StoreKeys.ExtServerHost]
+        : undefined,
+    [StoreKeys.BackupsLocation]: sanitizeBackupsLocation(
+      data[StoreKeys.BackupsLocation]
+    ),
+    [StoreKeys.ZoomFactor]: sanitizeZoomFactor(data[StoreKeys.ZoomFactor]),
+    [StoreKeys.SelectedSpellCheckerLanguageCodes]: sanitizeSpellCheckerLanguageCodes(
+      data[StoreKeys.SelectedSpellCheckerLanguageCodes]
+    )
+  };
+}
+
+function sanitizeZoomFactor(factor?: any): number {
+  if (typeof factor === 'number' && factor > 0) {
+    return factor;
+  } else {
+    return 1;
+  }
+}
+
+function sanitizeBackupsLocation(location?: unknown): string {
+  const defaultPath = path.join(
+    (app || remote.app).getPath('home'),
+    'Standard Notes Backups'
+  );
+  if (typeof location !== 'string') {
+    return defaultPath;
+  }
+  try {
+    const stat = fs.lstatSync(location);
+    if (stat.isDirectory()) {
+      return location;
+    }
+    return defaultPath;
+  } catch (e) {
+    logError(e);
+    return defaultPath;
+  }
+}
+
+function sanitizeSpellCheckerLanguageCodes(
+  languages?: unknown
+): Set<Language> | null {
+  if (!languages) return null;
+  if (!Array.isArray(languages)) return null;
+
+  const set = new Set<Language>();
+  const validLanguages = Object.values(Language);
+  for (const language of languages) {
+    if (validLanguages.includes(language)) {
+      set.add(language);
+    }
+  }
+  return set;
+}
+
+export function serializeStoreData(data: StoreData): string {
+  return JSON.stringify(data, (_key, value) => {
+    if (value instanceof Set) {
+      return Array.from(value);
+    }
+    return value;
+  });
+}
+
+function parseDataFile(filePath: string) {
+  try {
+    const fileData = fs.readFileSync(filePath);
+    const userData = JSON.parse(fileData.toString());
+    return createSanitizedStoreData(userData);
+  } catch (error) {
+    logError(error);
+    return createSanitizedStoreData({});
+  }
+}
 
 export class Store {
   static instance: Store;
@@ -27,20 +134,15 @@ export class Store {
 
   static getInstance() {
     if (!this.instance) {
-      this.instance = new Store({
-        configName: 'user-preferences',
-        defaults: {
-          [StoreKeys.UseSystemMenuBar]: false,
-          [StoreKeys.MenuBarVisible]: true,
-          /**
-           * `null` indicates that no language has ever been set. An empty
-           * set indicates a user intentionally deselecting every language
-           */
-          [StoreKeys.SelectedSpellCheckerLanguageCodes]: null
-        }
-      });
+      /**
+       * Renderer process has to get `app` module via `remote`, whereas the main process
+       * can get it directly app.getPath('userData') will return a string of the user's
+       * app data directory path.
+       * TODO(baptiste): stop using Store in the renderer process.
+       */
+      const userDataPath = (app || remote.app).getPath('userData')
+      this.instance = new Store(userDataPath);
     }
-
     return this.instance;
   }
 
@@ -48,52 +150,28 @@ export class Store {
     return this.getInstance().get(key);
   }
 
-  static set(key: StoreKeys, val: any) {
-    return this.getInstance().set(key, val);
+  constructor(userDataPath: string) {
+    this.path = path.join(userDataPath, 'user-preferences.json');
+    this.data = parseDataFile(this.path);
+
+    if (isTesting()) {
+      /** Set up test utility methods. */
+      ipcMain.handle(TestIpcMessages.StoreData, () =>
+        serializeStoreData(this.data)
+      );
+      ipcMain.handle(TestIpcMessages.StoreSettingsLocation, () => this.path);
+      ipcMain.handle(TestIpcMessages.StoreSet, (_e, key, value) => {
+        this.set(key, value)
+      });
+    }
   }
 
-  constructor(opts: { configName: string; defaults: StoreData }) {
-    /**
-     * Renderer process has to get `app` module via `remote`, whereas the main process
-     * can get it directly app.getPath('userData') will return a string of the user's
-     * app data directory path.
-     */
-    const userDataPath = (electron.app || electron.remote.app).getPath('userData');
-    this.path = path.join(userDataPath, opts.configName + '.json');
-    this.data = parseDataFile(this.path, opts.defaults);
-  }
-
-  get(key: StoreKeys) {
+  get<T extends keyof StoreData>(key: T): StoreData[T] {
     return this.data[key];
   }
 
-  set(key: StoreKeys, val: any) {
+  set<T extends keyof StoreData>(key: T, val: StoreData[T]) {
     this.data[key] = val;
-    fs.writeFileSync(this.path, JSON.stringify(this.data, (_key, value) => {
-      if (value instanceof Set) {
-        return Array.from(value);
-      }
-      return value;
-    }));
-  }
-}
-
-function parseDataFile(filePath: string, defaults: StoreData) {
-  try {
-    const userData = JSON.parse(fs.readFileSync(filePath).toString());
-
-    /** Convert spellchecker language codes array into a set. */
-    if (userData[StoreKeys.SelectedSpellCheckerLanguageCodes]) {
-      userData[StoreKeys.SelectedSpellCheckerLanguageCodes] = new Set(
-        userData[StoreKeys.SelectedSpellCheckerLanguageCodes]
-      );
-    }
-
-    return {
-      ...defaults,
-      ...userData
-    };
-  } catch (error) {
-    return defaults;
+    fs.writeFileSync(this.path, serializeStoreData(this.data));
   }
 }

--- a/app/javascripts/main/store.ts
+++ b/app/javascripts/main/store.ts
@@ -1,9 +1,9 @@
-import { app, remote, ipcMain, App } from 'electron';
+import { app, ipcMain, remote } from 'electron';
 import fs from 'fs';
 import path from 'path';
+import { TestIpcMessages } from '../../../test/TestIpcMessages';
 import { Language } from './spellcheckerManager';
 import { isTesting } from './utils';
-import { TestIpcMessages } from '../../../test/TestIpcMessages';
 
 function logError(...message: any) {
   console.error('store:', ...message);
@@ -140,7 +140,7 @@ export class Store {
        * app data directory path.
        * TODO(baptiste): stop using Store in the renderer process.
        */
-      const userDataPath = (app || remote.app).getPath('userData')
+      const userDataPath = (app || remote.app).getPath('userData');
       this.instance = new Store(userDataPath);
     }
     return this.instance;
@@ -161,7 +161,7 @@ export class Store {
       );
       ipcMain.handle(TestIpcMessages.StoreSettingsLocation, () => this.path);
       ipcMain.handle(TestIpcMessages.StoreSet, (_e, key, value) => {
-        this.set(key, value)
+        this.set(key, value);
       });
     }
   }

--- a/app/javascripts/main/store.ts
+++ b/app/javascripts/main/store.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { TestIpcMessages } from '../../../test/TestIpcMessages';
 import { Language } from './spellcheckerManager';
-import { isTesting } from './utils';
+import { ensureIsBoolean, isTesting, stringOrNull } from './utils';
 
 function logError(...message: any) {
   console.error('store:', ...message);
@@ -33,26 +33,23 @@ interface StoreData {
 
 function createSanitizedStoreData(data: any = {}): StoreData {
   return {
-    [StoreKeys.MenuBarVisible]:
-      typeof data[StoreKeys.MenuBarVisible] === 'boolean'
-        ? data[StoreKeys.MenuBarVisible]
-        : true,
-    [StoreKeys.UseSystemMenuBar]:
-      typeof data[StoreKeys.UseSystemMenuBar] === 'boolean'
-        ? data[StoreKeys.UseSystemMenuBar]
-        : false,
-    [StoreKeys.BackupsDisabled]:
-      typeof data[StoreKeys.BackupsDisabled] === 'boolean'
-        ? data[StoreKeys.BackupsDisabled]
-        : false,
-    [StoreKeys.MinimizeToTray]:
-      typeof data[StoreKeys.MinimizeToTray] === 'boolean'
-        ? data[StoreKeys.MinimizeToTray]
-        : false,
-    [StoreKeys.ExtServerHost]:
-      typeof data[StoreKeys.ExtServerHost] === 'string'
-        ? data[StoreKeys.ExtServerHost]
-        : undefined,
+    [StoreKeys.MenuBarVisible]: ensureIsBoolean(
+      data[StoreKeys.MenuBarVisible],
+      true
+    ),
+    [StoreKeys.UseSystemMenuBar]: ensureIsBoolean(
+      data[StoreKeys.UseSystemMenuBar],
+      false
+    ),
+    [StoreKeys.BackupsDisabled]: ensureIsBoolean(
+      data[StoreKeys.BackupsDisabled],
+      false
+    ),
+    [StoreKeys.MinimizeToTray]: ensureIsBoolean(
+      data[StoreKeys.MinimizeToTray],
+      false
+    ),
+    [StoreKeys.ExtServerHost]: stringOrNull(data[StoreKeys.ExtServerHost]),
     [StoreKeys.BackupsLocation]: sanitizeBackupsLocation(
       data[StoreKeys.BackupsLocation]
     ),

--- a/app/javascripts/main/strings/french.ts
+++ b/app/javascripts/main/strings/french.ts
@@ -1,9 +1,10 @@
 import { Strings } from './types';
 import { createEnglishStrings } from './english';
+import { isDev } from '../utils';
 
 export function createFrenchStrings(): Strings {
   const fallback = createEnglishStrings();
-  if (process.env.NODE_ENV !== 'development') {
+  if (isDev()) {
     /**
      * Le Français est une langue expérimentale.
      * Don't show it in production yet.

--- a/app/javascripts/main/strings/index.ts
+++ b/app/javascripts/main/strings/index.ts
@@ -1,6 +1,7 @@
 import { createEnglishStrings } from './english';
 import { createFrenchStrings } from './french';
 import { Strings } from './types';
+import { isDev } from '../utils';
 
 let strings: Strings;
 
@@ -10,7 +11,7 @@ let strings: Strings;
  * @see https://www.electronjs.org/docs/api/locales
  */
 export function initializeStrings(locale: string) {
-  if (process.env.NODE_ENV === 'development') {
+  if (isDev()) {
     if (strings) {
       throw new Error('`strings` has already been initialized');
     }
@@ -20,7 +21,7 @@ export function initializeStrings(locale: string) {
 }
 
 export function str(): Strings {
-  if (process.env.NODE_ENV === 'development') {
+  if (isDev()) {
     if (!strings) {
       throw new Error('tried to access strings before they were initialized.');
     }

--- a/app/javascripts/main/trayManager.ts
+++ b/app/javascripts/main/trayManager.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { isLinux, isWindows } from './platforms';
 import { Store, StoreKeys } from './store';
 import { AppName, tray as str } from './strings';
+import { isDev } from './utils';
 
 const icon = path.join(__dirname, '/icon/Icon-256x256.png');
 
@@ -90,7 +91,7 @@ export function createTrayManager(
     },
 
     destroyTrayIcon() {
-      if (process.env.NODE_ENV === 'development') {
+      if (isDev()) {
         /** Check our state */
         if (!updateContextMenu) {
           throw new Error('updateContextMenu === undefined');

--- a/app/javascripts/main/updateManager.ts
+++ b/app/javascripts/main/updateManager.ts
@@ -7,6 +7,7 @@ import { readJSONFile, writeJSONFile } from './fileUtils';
 import { downloadFile, getJSON } from './networking';
 import { InstallerKey, installerKey } from './platforms';
 import { updates as str } from './strings';
+import { isDev } from './utils';
 
 const DefaultUpdateEndpoint =
   process.env.UPDATE_ENDPOINT ||
@@ -115,7 +116,7 @@ export function createUpdateManager(window: BrowserWindow): UpdateManager {
   }
 
   async function checkForAutoUpdate(force = false) {
-    if (process.env.NODE_ENV === 'development') return;
+    if (isDev()) return;
 
     if (settings.autoupdateEnabled || force) {
       try {

--- a/app/javascripts/main/utils.ts
+++ b/app/javascripts/main/utils.ts
@@ -1,8 +1,9 @@
 import { CommandLineArgs } from '../shared/CommandLineArgs';
 
+export function isDev(): boolean {
+  return process.env.NODE_ENV === 'development';
+}
+
 export function isTesting(): boolean {
-  return (
-    process.env.NODE_ENV === 'development' &&
-    process.argv.includes(CommandLineArgs.Testing)
-  );
+  return isDev() && process.argv.includes(CommandLineArgs.Testing);
 }

--- a/app/javascripts/main/utils.ts
+++ b/app/javascripts/main/utils.ts
@@ -7,3 +7,17 @@ export function isDev(): boolean {
 export function isTesting(): boolean {
   return isDev() && process.argv.includes(CommandLineArgs.Testing);
 }
+
+export function ensureIsBoolean(arg: any, fallbackValue: boolean): boolean {
+  if (typeof arg === 'boolean') {
+    return arg;
+  }
+  return fallbackValue;
+}
+
+export function stringOrNull(arg: any): string | null {
+  if (typeof arg === 'string') {
+    return arg;
+  }
+  return null;
+}

--- a/app/javascripts/main/utils.ts
+++ b/app/javascripts/main/utils.ts
@@ -1,0 +1,8 @@
+import { CommandLineArgs } from '../shared/CommandLineArgs';
+
+export function isTesting(): boolean {
+  return (
+    process.env.NODE_ENV === 'development' &&
+    process.argv.includes(CommandLineArgs.Testing)
+  );
+}

--- a/app/javascripts/main/window.ts
+++ b/app/javascripts/main/window.ts
@@ -1,8 +1,7 @@
-import { BrowserWindow, Shell, ipcMain } from 'electron';
+import { BrowserWindow, ipcMain, Shell } from 'electron';
 import windowStateKeeper from 'electron-window-state';
 import path from 'path';
 import { AppState } from '../../application';
-import { CommandLineArgs } from '../shared/CommandLineArgs';
 import { IpcMessages } from '../shared/ipcMessages';
 import { ArchiveManager, createArchiveManager } from './archiveManager';
 import { createMenuManager, MenuManager } from './menuManager';
@@ -13,8 +12,8 @@ import { createSpellcheckerManager } from './spellcheckerManager';
 import { Store, StoreKeys } from './store';
 import { createTrayManager, TrayManager } from './trayManager';
 import { createUpdateManager, UpdateManager } from './updateManager';
-import { initializeZoomManager } from './zoomManager';
 import { isTesting } from './utils';
+import { initializeZoomManager } from './zoomManager';
 
 const WINDOW_DEFAULT_WIDTH = 1100;
 const WINDOW_DEFAULT_HEIGHT = 800;
@@ -99,7 +98,11 @@ function createWindowServices(
   initializePackageManager(window.webContents);
   initializeSearchManager(window.webContents);
   initializeZoomManager(window.webContents, store);
-  const archiveManager = createArchiveManager(window.webContents, store, ipcMain);
+  const archiveManager = createArchiveManager(
+    window.webContents,
+    store,
+    ipcMain
+  );
   const updateManager = createUpdateManager(window);
   const trayManager = createTrayManager(window, store);
   const spellcheckerManager = createSpellcheckerManager(

--- a/test/TestIpcMessages.ts
+++ b/test/TestIpcMessages.ts
@@ -1,0 +1,5 @@
+export const enum TestIpcMessages {
+  StoreData = 'Store.data',
+  StoreSettingsLocation = 'Store.settingsLocation',
+  StoreSet = 'Store.set'
+}

--- a/test/store.ts
+++ b/test/store.ts
@@ -1,11 +1,10 @@
 import { strict as assert } from 'assert';
+import fs from 'fs';
 import { Suite } from 'mocha';
 import { Application } from 'spectron';
-import { CommandLineArgs } from '../app/javascripts/shared/CommandLineArgs';
-import { launchApp, setDefaults } from './utils';
-import fs from 'fs';
-import { TestIpcMessages } from './TestIpcMessages';
 import { serializeStoreData } from '../app/javascripts/main/store';
+import { TestIpcMessages } from './TestIpcMessages';
+import { launchApp, setDefaults } from './utils';
 
 function getDataLocation(app: Application) {
   return app.electron.ipcRenderer.invoke(TestIpcMessages.StoreSettingsLocation);
@@ -20,7 +19,6 @@ async function validateData(app: Application) {
   const data = JSON.parse(
     await app.electron.ipcRenderer.invoke(TestIpcMessages.StoreData)
   );
-
 
   /**
    * There should always be 8 values in the store.

--- a/test/store.ts
+++ b/test/store.ts
@@ -1,0 +1,117 @@
+import { strict as assert } from 'assert';
+import { Suite } from 'mocha';
+import { Application } from 'spectron';
+import { CommandLineArgs } from '../app/javascripts/shared/CommandLineArgs';
+import { launchApp, setDefaults } from './utils';
+import fs from 'fs';
+import { TestIpcMessages } from './TestIpcMessages';
+import { serializeStoreData } from '../app/javascripts/main/store';
+
+function getDataLocation(app: Application) {
+  return app.electron.ipcRenderer.invoke(TestIpcMessages.StoreSettingsLocation);
+}
+
+async function readDataFromDisk(app: Application) {
+  const location = await getDataLocation(app);
+  return JSON.parse((await fs.promises.readFile(location)).toString());
+}
+
+async function validateData(app: Application) {
+  const data = JSON.parse(
+    await app.electron.ipcRenderer.invoke(TestIpcMessages.StoreData)
+  );
+
+
+  /**
+   * There should always be 8 values in the store.
+   * If one was added/removed intentionally, update this number
+   */
+  const numberOfStoreKeys = 8;
+  assert.equal(Object.keys(data).length, numberOfStoreKeys);
+
+  assert.equal(typeof data.isMenuBarVisible, 'boolean');
+
+  assert.equal(typeof data.useSystemMenuBar, 'boolean');
+
+  assert.equal(typeof data.backupsDisabled, 'boolean');
+
+  assert.equal(typeof data.minimizeToTray, 'boolean');
+
+  assert.equal(typeof data.zoomFactor, 'number');
+  assert(data.zoomFactor > 0);
+
+  assert.equal(typeof data.extServerHost, 'string');
+  /** Must not throw */
+  const extServerHost = new URL(data.extServerHost);
+  assert.equal(extServerHost.hostname, '127.0.0.1');
+  assert.equal(extServerHost.protocol, 'http:');
+  assert.equal(extServerHost.port, '45653');
+
+  assert.equal(typeof data.backupsLocation, 'string');
+  const stat = fs.lstatSync(data.backupsLocation);
+  assert(stat.isDirectory());
+
+  assert(Array.isArray(data.selectedSpellCheckerLanguageCodes));
+  for (const language of data.selectedSpellCheckerLanguageCodes) {
+    assert.equal(typeof language, 'string');
+  }
+}
+
+describe('Store', function(this: Suite) {
+  setDefaults(this);
+
+  let app: Application;
+
+  before(async function() {
+    app = await launchApp();
+  });
+
+  after(async function() {
+    if (app.isRunning()) {
+      await app.stop();
+    }
+  });
+
+  it('has valid data', async function() {
+    await validateData(app);
+  });
+
+  it('recreates a missing data file', async function() {
+    const location = await getDataLocation(app);
+    await app.stop();
+    /** Delete the store's backing file */
+    fs.unlinkSync(location);
+    await app.start();
+    await validateData(app);
+  });
+
+  it('recovers from corrupted data', async function() {
+    const location = await getDataLocation(app);
+    await app.stop();
+    /** Write bad data in the store's file */
+    fs.writeFileSync(location, '\uFFFF'.repeat(300));
+    await app.start();
+    await validateData(app);
+  });
+
+  it('persists changes to disk after setting a value', async function() {
+    await app.electron.ipcRenderer.invoke(
+      TestIpcMessages.StoreSet,
+      'zoomFactor',
+      4.8
+    );
+    const diskData = await readDataFromDisk(app);
+    assert.equal(diskData.zoomFactor, 4.8);
+  });
+
+  it('serializes string sets to an array', async function() {
+    assert.deepStrictEqual(
+      serializeStoreData({
+        set: new Set(['value'])
+      } as any),
+      JSON.stringify({
+        set: ['value']
+      })
+    );
+  });
+});


### PR DESCRIPTION
See `test/store.ts` for a list of what is now being tested.
This is also my first go at making the app more testable without compromising on infrastructure or giving up on executing tests in the context of a full app launch and execution. It's based on exposing custom behavior over IPC when the app is in test mode.
Let me know if you have ideas on how else to do it, or how to iterate on this model, as well as what else you think we could test with the store!