### PR TITLE
Add support for building deb

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "build:all": "yarn bundle && electron-builder -wl --x64 --ia32 && yarn build:mac && yarn build:snap && yarn build:write-sums",
     "build:mac": "node scripts/build.mjs mac",
     "build:snap": "node scripts/build.mjs snap",
+    "build:deb": "node scripts/build.mjs deb",
     "build:write-sums": "node scripts/sums.mjs",
     "build:remove-unpacked": "rimraf dist/{linux-*,mac,win-*}",
     "build:web": "git submodule update && cd web && rimraf node_modules && yarn setup && yarn run bundle:desktop",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -23,8 +23,9 @@ const appimageX64 = 'appimage-x64';
 const dir = 'dir';
 const mac = 'mac';
 const snap = 'snap';
+const deb = 'deb';
 const windows = 'windows';
-const availableTargets = [appimage, appimageX64, dir, mac, snap, windows];
+const availableTargets = [appimage, appimageX64, dir, mac, snap, deb, windows];
 
 (async () => {
   try {
@@ -74,6 +75,12 @@ const availableTargets = [appimage, appimageX64, dir, mac, snap, windows];
         );
         await runCommand(
           'yarn run electron-builder --linux --x64 --ia32 -c.linux.target=snap --publish=never'
+        );
+        break;
+      case deb:
+        await runCommand('yarn run webpack --config webpack.prod.js --env deb');
+        await runCommand(
+          'yarn run electron-builder --linux --x64 --ia32 -c.linux.target=deb --publish=never'
         );
         break;
       case windows:


### PR DESCRIPTION
I know you don't want to build a deb yourselves (which is perfectly ok) but adding support for building a deb would allow people like myself to build and use Standard Notes as deb (which improve system integration) from the latest version of the official source code without having to modify it. Please consider adding this functionality and thank you very much for this amazing app!

I've tested this specific code change and it works without any issues.