### PR TITLE
Fix typo ("mananger") #767

### DIFF
--- a/app/grantLinuxPasswordsAccess.html
+++ b/app/grantLinuxPasswordsAccess.html
@@ -27,7 +27,7 @@
               </h1>
               <p class="sk-p">
                 Standard Notes can either use your operating system's password
-                mananger or its own local storage facility.
+                manager or its own local storage facility.
               </p>
               <p class="sk-p">
                 <strong


### PR DESCRIPTION
Changes the word "mananger" on the first login screen to "manager".

Fixes #767.